### PR TITLE
INF-1217 add default codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @payground-devops/devops


### PR DESCRIPTION
## Summary
Add default codeowners for all repos under the payground-devops org.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add default CODEOWNERS file that assigns ownership of all files to the @payground-devops/devops team.

### Why are these changes being made?

This change ensures that any changes to the repository are automatically reviewed by the devops team, providing a streamlined process for maintaining consistent oversight and code quality within the project.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->